### PR TITLE
Integrated the latest version of bouncycastle.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,14 +8,14 @@
     <name>otr4j library</name>
     <url>http://github.com/gpolitis/otr4j</url>
     <description>
-      otr4j is an implementation of the OTR (Off The Record) protocol in java.
+        otr4j is an implementation of the OTR (Off The Record) protocol in java.
 
-      Off-the-Record Messaging, is a cryptographic protocol that uses a combination of 
-      the Advanced Encryption Standard (AES), the Diffie-Hellman key exchange, and the
-      SHA hash functions. In addition to authentication and encryption, OTR provides perfect
-      forward secrecy and malleable encryption.
+        Off-the-Record Messaging, is a cryptographic protocol that uses a combination of
+        the Advanced Encryption Standard (AES), the Diffie-Hellman key exchange, and the
+        SHA hash functions. In addition to authentication and encryption, OTR provides perfect
+        forward secrecy and malleable encryption.
 
-      The OTR protocol was designed by Ian Goldberg and the OTR Development Team.
+        The OTR protocol was designed by Ian Goldberg and the OTR Development Team.
     </description>
     <licenses>
         <license>
@@ -39,11 +39,11 @@
             <version>4.9</version>
             <scope>test</scope>
         </dependency>
-	<dependency>
-	  <groupId>com.madgag</groupId>
-	  <artifactId>sc-light-jdk15on</artifactId>
-	  <version>1.47.0.2</version>
-	</dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.49</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -60,9 +60,9 @@
         </plugins>
     </build>
     <distributionManagement>
-      <repository>
-	<id>gh-pages</id>
-	<url>file:///${basedir}/../gh-pages/repository/</url>
-      </repository>
+        <repository>
+            <id>gh-pages</id>
+            <url>file:///${basedir}/../gh-pages/repository/</url>
+        </repository>
     </distributionManagement>
 </project>

--- a/src/main/java/net/java/otr4j/OtrEngineHost.java
+++ b/src/main/java/net/java/otr4j/OtrEngineHost.java
@@ -55,7 +55,7 @@ public abstract interface OtrEngineHost {
 
 	public abstract void unverify(SessionID sessionID);
 
-	public abstract String getReplyForUnreadableMessage();
+	public abstract String getReplyForUnreadableMessage(SessionID sessionID);
 
-	public abstract String getFallbackMessage();
+	public abstract String getFallbackMessage(SessionID sessionID);
 }

--- a/src/main/java/net/java/otr4j/OtrKeyManagerImpl.java
+++ b/src/main/java/net/java/otr4j/OtrKeyManagerImpl.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Vector;
 
-import org.spongycastle.util.encoders.Base64;
+import org.bouncycastle.util.encoders.Base64;
 
 import net.java.otr4j.crypto.OtrCryptoEngineImpl;
 import net.java.otr4j.crypto.OtrCryptoException;

--- a/src/main/java/net/java/otr4j/crypto/OtrCryptoEngineImpl.java
+++ b/src/main/java/net/java/otr4j/crypto/OtrCryptoEngineImpl.java
@@ -30,22 +30,22 @@ import javax.crypto.spec.SecretKeySpec;
 
 import net.java.otr4j.io.SerializationUtils;
 
-import org.spongycastle.crypto.AsymmetricCipherKeyPair;
-import org.spongycastle.crypto.BufferedBlockCipher;
-import org.spongycastle.crypto.engines.AESFastEngine;
-import org.spongycastle.crypto.generators.DHKeyPairGenerator;
-import org.spongycastle.crypto.modes.SICBlockCipher;
-import org.spongycastle.crypto.params.DHKeyGenerationParameters;
-import org.spongycastle.crypto.params.DHParameters;
-import org.spongycastle.crypto.params.DHPrivateKeyParameters;
-import org.spongycastle.crypto.params.DHPublicKeyParameters;
-import org.spongycastle.crypto.params.DSAParameters;
-import org.spongycastle.crypto.params.DSAPrivateKeyParameters;
-import org.spongycastle.crypto.params.DSAPublicKeyParameters;
-import org.spongycastle.crypto.params.KeyParameter;
-import org.spongycastle.crypto.params.ParametersWithIV;
-import org.spongycastle.crypto.signers.DSASigner;
-import org.spongycastle.util.BigIntegers;
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
+import org.bouncycastle.crypto.BufferedBlockCipher;
+import org.bouncycastle.crypto.engines.AESFastEngine;
+import org.bouncycastle.crypto.generators.DHKeyPairGenerator;
+import org.bouncycastle.crypto.modes.SICBlockCipher;
+import org.bouncycastle.crypto.params.DHKeyGenerationParameters;
+import org.bouncycastle.crypto.params.DHParameters;
+import org.bouncycastle.crypto.params.DHPrivateKeyParameters;
+import org.bouncycastle.crypto.params.DHPublicKeyParameters;
+import org.bouncycastle.crypto.params.DSAParameters;
+import org.bouncycastle.crypto.params.DSAPrivateKeyParameters;
+import org.bouncycastle.crypto.params.DSAPublicKeyParameters;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.crypto.params.ParametersWithIV;
+import org.bouncycastle.crypto.signers.DSASigner;
+import org.bouncycastle.util.BigIntegers;
 
 /**
  * 

--- a/src/main/java/net/java/otr4j/io/OtrOutputStream.java
+++ b/src/main/java/net/java/otr4j/io/OtrOutputStream.java
@@ -14,7 +14,7 @@ import net.java.otr4j.io.messages.SignatureM;
 import net.java.otr4j.io.messages.MysteriousT;
 import net.java.otr4j.io.messages.SignatureX;
 
-import org.spongycastle.util.BigIntegers;
+import org.bouncycastle.util.BigIntegers;
 
 public class OtrOutputStream extends FilterOutputStream implements
 		SerializationConstants {

--- a/src/main/java/net/java/otr4j/io/SerializationUtils.java
+++ b/src/main/java/net/java/otr4j/io/SerializationUtils.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 
 import javax.crypto.interfaces.DHPublicKey;
 
-import org.spongycastle.util.encoders.Base64;
+import org.bouncycastle.util.encoders.Base64;
 
 import net.java.otr4j.io.messages.AbstractEncodedMessage;
 import net.java.otr4j.io.messages.AbstractMessage;
@@ -271,7 +271,7 @@ public class SerializationUtils {
 				// Data message found.
 
 				ByteArrayInputStream bin = new ByteArrayInputStream(Base64
-						.decode(content.getBytes()));
+						.decode(content.substring(0, content.length() - 1).getBytes()));
 				OtrInputStream otr = new OtrInputStream(bin);
 				// We have an encoded message.
 				int protocolVersion = otr.readShort();

--- a/src/main/java/net/java/otr4j/io/SerializationUtils.java
+++ b/src/main/java/net/java/otr4j/io/SerializationUtils.java
@@ -270,6 +270,12 @@ public class SerializationUtils {
 			} else if (idxHead == 0 && contentType == SerializationConstants.HEAD_ENCODED) {
 				// Data message found.
 
+                /*
+                 * BC 1.48 added a check to throw an exception if a non-base64 character is encountered.
+                 * An OTR message consists of ?OTR:AbcDefFe. (note the terminating point).
+                 * Otr4j doesn't strip this point before passing the content to the base64 decoder.
+                 * So in order to decode the content string we have to get rid of the '.' first.
+                 */
 				ByteArrayInputStream bin = new ByteArrayInputStream(Base64
 						.decode(content.substring(0, content.length() - 1).getBytes()));
 				OtrInputStream otr = new OtrInputStream(bin);

--- a/src/main/java/net/java/otr4j/session/OtrSm.java
+++ b/src/main/java/net/java/otr4j/session/OtrSm.java
@@ -169,6 +169,10 @@ public class OtrSm {
         return makeTlvList(sendtlv);
 	}
 
+	public boolean isSmpInProgress() {
+	    return smstate.nextExpected > SM.EXPECT1;
+	}
+	
 	public boolean doProcessTlv(TLV tlv) throws OtrException {
 		/* If TLVs contain SMP data, process it */
 		int nextMsg = smstate.nextExpected;

--- a/src/main/java/net/java/otr4j/session/Session.java
+++ b/src/main/java/net/java/otr4j/session/Session.java
@@ -47,6 +47,8 @@ public interface Session {
 			throws OtrException;
 
 	public abstract void abortSmp() throws OtrException;
+	
+	public abstract boolean isSmpInProgress();
 
 	public abstract BigInteger getS();
 }

--- a/src/main/java/net/java/otr4j/session/SessionImpl.java
+++ b/src/main/java/net/java/otr4j/session/SessionImpl.java
@@ -501,7 +501,7 @@ public class SessionImpl implements Session {
 		case PLAINTEXT:
 			getHost().unreadableMessageReceived(this.getSessionID());
 			injectMessage(new ErrorMessage(AbstractMessage.MESSAGE_ERROR,
-					getHost().getReplyForUnreadableMessage()));
+					getHost().getReplyForUnreadableMessage(getSessionID())));
 			break;
 		}
 
@@ -516,7 +516,7 @@ public class SessionImpl implements Session {
 			throw new OtrException(e);
 		}
 		if (m instanceof QueryMessage)
-			msg += getHost().getFallbackMessage();
+			msg += getHost().getFallbackMessage(getSessionID());
 		getHost().injectMessage(getSessionID(), msg);
 	}
 
@@ -821,4 +821,7 @@ public class SessionImpl implements Session {
 		getHost().injectMessage(getSessionID(), msg);
 	}
 
+	public boolean isSmpInProgress() {
+	    return otrSm.isSmpInProgress();
+	}
 }

--- a/src/test/java/net/java/otr4j/OtrEngineImplTest.java
+++ b/src/test/java/net/java/otr4j/OtrEngineImplTest.java
@@ -81,7 +81,7 @@ public class OtrEngineImplTest extends junit.framework.TestCase {
 			logger.severe("IM shows error to user: " + error);
 		}
 
-		public String getReplyForUnreadableMessage() {
+		public String getReplyForUnreadableMessage(SessionID sessionID) {
 			return "You sent me an unreadable encrypted message.";
 		}
 
@@ -127,7 +127,7 @@ public class OtrEngineImplTest extends junit.framework.TestCase {
 			return null;
 		}
 
-		public String getFallbackMessage() {
+		public String getFallbackMessage(SessionID sessionID) {
 			return "Off-the-Record private conversation has been requested. However, you do not have a plugin to support that.";
 		}
 


### PR DESCRIPTION
- BC 1.48 added a check to throw an exception if a non-base64 character is
  encountered. An OTR message consists of ?OTR:AbcDefFe. (note the terminating
  point). Otr4j doesn't strip this point before passing the content to the
  base64 decoder - buuum. This is why .decode(content.substring(0, content.length() - 1).getBytes())) is needed.
  Changed some method signatures in OtrEngineHost. Added new method in Session which allows users to check whether SMP negotiation is in progress
