### PR TITLE
Added new method to the OtrEngineListener interface.

### DIFF
--- a/src/main/java/net/java/otr4j/OtrEngineImpl.java
+++ b/src/main/java/net/java/otr4j/OtrEngineImpl.java
@@ -54,6 +54,11 @@ public class OtrEngineImpl implements OtrEngine {
 					for (OtrEngineListener l : listeners)
 						l.sessionStatusChanged(sessionID);
 				}
+
+				public void sessionIsStarting(SessionID sessionID) {
+				    for (OtrEngineListener l : listeners)
+                        l.sessionIsStarting(sessionID);
+				}
 			});
 			return session;
 		} else

--- a/src/main/java/net/java/otr4j/OtrEngineListener.java
+++ b/src/main/java/net/java/otr4j/OtrEngineListener.java
@@ -11,4 +11,6 @@ import net.java.otr4j.session.SessionID;
  */
 public interface OtrEngineListener {
 	public abstract void sessionStatusChanged(SessionID sessionID);
+
+	public abstract void sessionIsStarting(SessionID sessionID);
 }

--- a/src/main/java/net/java/otr4j/session/SessionImpl.java
+++ b/src/main/java/net/java/otr4j/session/SessionImpl.java
@@ -727,7 +727,7 @@ public class SessionImpl implements Session {
 			throw new UnsupportedOperationException();
 
 		for (OtrEngineListener l : this.listeners)
-		    l.sessionStatusChanged(getSessionID());
+		    l.sessionIsStarting(getSessionID());
 
 		this.getAuthContext().startV2Auth();
 	}

--- a/src/main/java/net/java/otr4j/session/SessionImpl.java
+++ b/src/main/java/net/java/otr4j/session/SessionImpl.java
@@ -726,6 +726,9 @@ public class SessionImpl implements Session {
 		if (!getSessionPolicy().getAllowV2())
 			throw new UnsupportedOperationException();
 
+		for (OtrEngineListener l : this.listeners)
+		    l.sessionStatusChanged(getSessionID());
+
 		this.getAuthContext().startV2Auth();
 	}
 


### PR DESCRIPTION
Hello,
- Added a new method to the OtrEngineListener interface. Signature: sessionIsStarting(SessionID session);
  in order for applications to react when a new session is about to start or more precisely, when OtrEngine.startSession(). The reaction for example can be sending a message to the user that initiating private conversation is in progress, or in Jitsi's case - change the padlock icon to "loading padlock"
