### PR TITLE
Fix instancetag parsing

### DIFF
--- a/src/main/java/net/java/otr4j/session/OtrAssembler.java
+++ b/src/main/java/net/java/otr4j/session/OtrAssembler.java
@@ -6,6 +6,7 @@
  */
 package net.java.otr4j.session;
 
+import java.math.BigInteger;
 import java.net.ProtocolException;
 
 /**
@@ -92,10 +93,10 @@ public final class OtrAssembler {
 
 			int receiverInstance;
 			try {
-				receiverInstance = Integer.parseInt(instances[1], 16);
+				receiverInstance = new BigInteger(instances[1], 16).intValue();
 			} catch (NumberFormatException e) {
 				discard();
-				throw new ProtocolException();
+				throw new ProtocolException("Invalid receiver instance id: " + instances[1]);
 			}
 			if (receiverInstance != 0
 					&& receiverInstance != ownInstance.getValue())
@@ -123,15 +124,15 @@ public final class OtrAssembler {
 			n = Integer.parseInt(params[1]);
 		} catch (NumberFormatException e) {
 			discard();
-			throw new ProtocolException();
+			throw new ProtocolException("Bad format for parameters");
 		} catch (ArrayIndexOutOfBoundsException e) {
 			discard();
-			throw new ProtocolException();
+			throw new ProtocolException("Expected at least 2 parameters");
 		}
 
 		if (k == 0 || n == 0 || k > n || params.length != 4 || params[3].length() != 0) {
 			discard();
-			throw new ProtocolException();
+			throw new ProtocolException("Expected exactly 4 parameters and parameters according to specification");
 		}
 
 		msgText = params[2];

--- a/src/main/java/net/java/otr4j/session/OtrAssembler.java
+++ b/src/main/java/net/java/otr4j/session/OtrAssembler.java
@@ -109,10 +109,13 @@ public final class OtrAssembler {
 				discard();
 				throw new ProtocolException("Invalid receiver instance id: " + instances[1]);
 			}
-            // FIXME should we also verify that the sender instance tag of the fragment is valid? The sender instance tag is now ignored completely.
+
+            // currently sender instance tag is not verified, as we also have no
+            // use for that instance tag. It is sufficient to know that the
+            // message fragment is intended for us, i.e. receiver instance tag.
+
 			if (receiverInstance != 0
-					&& receiverInstance != ownInstance.getValue())
-			{
+					&& receiverInstance != ownInstance.getValue()) {
 				// discard message for different instance id
 				throw new UnknownInstanceException(
 						"Message for unknown instance tag "
@@ -136,10 +139,10 @@ public final class OtrAssembler {
 			n = Integer.parseInt(params[1]);
 		} catch (NumberFormatException e) {
 			discard();
-			throw new ProtocolException("Bad format for parameters");
+			throw new ProtocolException("Bad format for parameter current/total fragment number");
 		} catch (ArrayIndexOutOfBoundsException e) {
 			discard();
-			throw new ProtocolException("Expected at least 2 parameters");
+			throw new ProtocolException("Expected 2 parameters: current and total fragment numbers");
 		}
 
 		if (k <= 0 || k > MAX_FRAGMENTS || n <= 0 || n > MAX_FRAGMENTS || k > n

--- a/src/main/java/net/java/otr4j/session/OtrAssembler.java
+++ b/src/main/java/net/java/otr4j/session/OtrAssembler.java
@@ -79,7 +79,7 @@ public final class OtrAssembler {
 			msgText = msgText.substring(
 					HEAD_FRAGMENT_V2.length());
 		} else if (msgText.startsWith(HEAD_FRAGMENT_V3)) {
-			// v
+			// v3
 			msgText = msgText.substring(
 					HEAD_FRAGMENT_V3.length());
 

--- a/src/main/java/net/java/otr4j/session/OtrAssembler.java
+++ b/src/main/java/net/java/otr4j/session/OtrAssembler.java
@@ -16,6 +16,8 @@ import java.net.ProtocolException;
  */
 public final class OtrAssembler {
 
+    private static final int MAX_FRAGMENTS = 65535;
+
 	/**
 	 * Accumulated fragment thus far.
 	 */
@@ -42,7 +44,7 @@ public final class OtrAssembler {
 	private static final String HEAD_FRAGMENT_V2 = "?OTR,";
 	private static final String HEAD_FRAGMENT_V3 = "?OTR|";
 
-	public OtrAssembler(InstanceTag ownInstance) {
+	public OtrAssembler(final InstanceTag ownInstance) {
 		this.ownInstance = ownInstance;
 		discard();
 	}
@@ -140,9 +142,9 @@ public final class OtrAssembler {
 			throw new ProtocolException("Expected at least 2 parameters");
 		}
 
-        // FIXME verify maximum value of 65535 for k, n
-        // FIXME disallow values < 0 too!
-		if (k == 0 || n == 0 || k > n || params.length != 4 || params[3].length() != 0) {
+		if (k <= 0 || k > MAX_FRAGMENTS || n <= 0 || n > MAX_FRAGMENTS || k > n
+                || params.length != 4 || params[2].isEmpty()
+                || !params[3].isEmpty()) {
 			discard();
 			throw new ProtocolException("Expected exactly 4 parameters and parameters according to specification");
 		}

--- a/src/main/java/net/java/otr4j/session/OtrAssembler.java
+++ b/src/main/java/net/java/otr4j/session/OtrAssembler.java
@@ -91,13 +91,23 @@ public final class OtrAssembler {
 				throw new ProtocolException();
 			}
 
-			int receiverInstance;
+            // parse receiver instance tag
+			final int receiverInstance;
 			try {
+                // Verify length before parsing as BigInteger, as BigInteger
+                // will support much larger tag values even though they are not
+                // valid according to spec. With conversion to int they will be
+                // truncated without warning, so we need to discover invalid
+                // tags before parsing.
+                if (instances[1].length() > 8) {
+                    throw new ProtocolException("Invalid receiver instance id: " + instances[1] + ". Instance tag is too big.");
+                }
 				receiverInstance = new BigInteger(instances[1], 16).intValue();
 			} catch (NumberFormatException e) {
 				discard();
 				throw new ProtocolException("Invalid receiver instance id: " + instances[1]);
 			}
+            // FIXME should we also verify that the sender instance tag of the fragment is valid? The sender instance tag is now ignored completely.
 			if (receiverInstance != 0
 					&& receiverInstance != ownInstance.getValue())
 			{
@@ -130,6 +140,8 @@ public final class OtrAssembler {
 			throw new ProtocolException("Expected at least 2 parameters");
 		}
 
+        // FIXME verify maximum value of 65535 for k, n
+        // FIXME disallow values < 0 too!
 		if (k == 0 || n == 0 || k > n || params.length != 4 || params[3].length() != 0) {
 			discard();
 			throw new ProtocolException("Expected exactly 4 parameters and parameters according to specification");

--- a/src/main/java/net/java/otr4j/session/SessionImpl.java
+++ b/src/main/java/net/java/otr4j/session/SessionImpl.java
@@ -360,7 +360,7 @@ public class SessionImpl implements Session {
 			getHost().messageFromAnotherInstanceReceived(getSessionID());
 			return null;
 		} catch (ProtocolException e) {
-			logger.warning("An invalid message fragment was discarded.");
+			logger.log(Level.WARNING, "An invalid message fragment was discarded.", e);
 			return null;
 		}
 

--- a/src/test/java/net/java/otr4j/session/OtrAssemblerTest.java
+++ b/src/test/java/net/java/otr4j/session/OtrAssemblerTest.java
@@ -88,4 +88,30 @@ public class OtrAssemblerTest {
         final OtrAssembler ass = new OtrAssembler(tag);
         ass.accumulate(data);
     }
+
+    @Test
+    public void testAssembleSinglePartMessage() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0xfedcba98);
+        final String data = String.format("?OTR|ff123456|%08x,00001,00001,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        assertEquals("test", ass.accumulate(data));
+    }
+
+    @Test
+    public void testAssembleTwoPartMessage() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0xfedcba98);
+        final OtrAssembler ass = new OtrAssembler(tag);
+        assertNull(ass.accumulate(String.format("?OTR|ff123456|%08x,00001,00002,abcdef,", tag.getValue())));
+        assertEquals("abcdefghijkl", ass.accumulate(String.format("?OTR|ff123456|%08x,00002,00002,ghijkl,", tag.getValue())));
+    }
+
+    @Test
+    public void testAssembleFourPartMessage() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0xfedcba98);
+        final OtrAssembler ass = new OtrAssembler(tag);
+        assertNull(ass.accumulate(String.format("?OTR|ff123456|%08x,00001,00004,a,", tag.getValue())));
+        assertNull(ass.accumulate(String.format("?OTR|ff123456|%08x,00002,00004,b,", tag.getValue())));
+        assertNull(ass.accumulate(String.format("?OTR|ff123456|%08x,00003,00004,c,", tag.getValue())));
+        assertEquals("abcd", ass.accumulate(String.format("?OTR|ff123456|%08x,00004,00004,d,", tag.getValue())));
+    }
 }

--- a/src/test/java/net/java/otr4j/session/OtrAssemblerTest.java
+++ b/src/test/java/net/java/otr4j/session/OtrAssemblerTest.java
@@ -1,0 +1,37 @@
+/*
+ * otr4j, the open source java otr library.
+ *
+ * Distributable under LGPL license.
+ * See terms of license at gnu.org.
+ */
+package net.java.otr4j.session;
+
+import java.net.ProtocolException;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for OTR Assembler.
+ *
+ * @author Danny van Heumen
+ */
+public class OtrAssemblerTest {
+
+    @Test
+    public void testCorrectParsingOf32bitsInteger() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0xff123456);
+        final String data = String.format("?OTR|ff123456|%08x,00001,00002,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        assertNull(ass.accumulate(data));
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void testCorrectDiscardingOf33bitsInteger() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0xff123456);
+        final String data = String.format("?OTR|ff123456|1%08x,00001,00002,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        ass.accumulate(data);
+    }
+
+    // FIXME test empty content in fragment (should give ProtocolException)
+}

--- a/src/test/java/net/java/otr4j/session/OtrAssemblerTest.java
+++ b/src/test/java/net/java/otr4j/session/OtrAssemblerTest.java
@@ -33,5 +33,59 @@ public class OtrAssemblerTest {
         ass.accumulate(data);
     }
 
-    // FIXME test empty content in fragment (should give ProtocolException)
+    @Test(expected = ProtocolException.class)
+    public void testCorrectDisallowEmptyPayload() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0xff123456);
+        final String data = String.format("?OTR|ff123456|%08x,00001,00002,,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        ass.accumulate(data);
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void testCorrectDisallowTrailingData() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0xff123456);
+        final String data = String.format("?OTR|ff123456|%08x,00001,00002,test,invalid", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        ass.accumulate(data);
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void testCorrectDisallowNegativeK() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0xff123456);
+        final String data = String.format("?OTR|ff123456|%08x,-0001,00002,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        ass.accumulate(data);
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void testCorrectDisallowKLargerThanN() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0xff123456);
+        final String data = String.format("?OTR|ff123456|%08x,00003,00002,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        ass.accumulate(data);
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void testCorrectDisallowKOverUpperBound() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0xff123456);
+        final String data = String.format("?OTR|ff123456|%08x,65536,65536,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        ass.accumulate(data);
+    }
+
+    @Test
+    public void testCorrectMaximumNFragments() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0xff123456);
+        final String data = String.format("?OTR|ff123456|%08x,00001,65535,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        assertNull(ass.accumulate(data));
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void testCorrectDisallowNOverUpperBound() throws ProtocolException {
+        final InstanceTag tag = new InstanceTag(0xff123456);
+        final String data = String.format("?OTR|ff123456|%08x,00001,65536,test,", tag.getValue());
+        final OtrAssembler ass = new OtrAssembler(tag);
+        ass.accumulate(data);
+    }
 }


### PR DESCRIPTION
This PR
- fixes InstanceTag parsing: Integer.parseInt cannot handle 32-bit hexadecimal values. It will accept only up to 31nd bit.
- Adds more verification of the values as defined by the specs.
- Adds unit tests.

Please have a careful look. I am porting this and upcoming PRs from a slightly different code base (and in a totally inconvenient order) so I wouldn't be surprised by the occasional mistake.

@hoijui Feel free to do a peer review here.
