### PR TITLE
Re-license code according to CLA and update link to CLA

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,7 +31,7 @@ update your settings!
 
 Want to hack on otr4j? Awesome! Here are the guidelines we'd like you to follow:
 
-* _All_ contributors submit code via pull requests. NOTE that before we can accept any patches from you, we need you to sign our contributor agreement available [here](http://bluejimp.com/bca.pdf).
+* _All_ contributors submit code via pull requests. NOTE that before we can accept any patches from you, we need you to sign our contributor agreement available [here](https://github.com/jitsi/jitsi/blob/master/CONTRIBUTING.md#contributor-license-agreement).
 * New commits must be pushed by the reviewer of the pull request, not the author.
 * Any developer can request push access and become a committer, regardless of project or organization affiliation.
 * We choose committers primarily on the Hippocratic Principle. You can find out more about the exact procedure [here][bca].

--- a/src/main/java/net/java/otr4j/session/OtrAssembler.java
+++ b/src/main/java/net/java/otr4j/session/OtrAssembler.java
@@ -1,8 +1,17 @@
 /*
- * otr4j, the open source java otr library.
+ * Copyright @ 2015 Atlassian Pty Ltd
  *
- * Distributable under LGPL license.
- * See terms of license at gnu.org.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package net.java.otr4j.session;
 

--- a/src/main/java/net/java/otr4j/session/UnknownInstanceException.java
+++ b/src/main/java/net/java/otr4j/session/UnknownInstanceException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.java.otr4j.session;
 
 import java.net.ProtocolException;


### PR DESCRIPTION
My contribution clearly is not worth arguing about so I decided to sign the CLA and change the license to Apache as requested.

Cf. #15

The PR also fixes the outdated link to the CLA in the README.
