### PR TITLE
Bouncy Castle 1.65 instead of 1.49

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.49</version>
+            <version>1.65</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
Bouncy Castle 1.65 instead of 1.49: https://www.bouncycastle.org/releasenotes.html

http://www.bouncycastle.org/latest_releases.html